### PR TITLE
fix: remove API signature debug prints and add buy amount validation

### DIFF
--- a/strategy_bitfinex_fng_ma_buyer.py
+++ b/strategy_bitfinex_fng_ma_buyer.py
@@ -42,6 +42,25 @@ def validate_env_vars():
     if missing:
         log_message(f"Error: Missing environment variables: {', '.join(missing)}", level="error")
         return False
+
+    amount_vars = {
+        'BUY_OVERLAP_AMOUNT': (0.000001, 10.0),
+        'BUY_FNG_AMOUNT': (0.000001, 10.0),
+        'BUY_MA_AMOUNT': (0.000001, 10.0),
+        'BUY_DAILY_AMOUNT': (0.0, 10.0),
+    }
+    for var, (min_val, max_val) in amount_vars.items():
+        raw = os.environ.get(var)
+        if raw is not None:
+            try:
+                val = float(raw)
+                if val != 0.0 and not (min_val <= val <= max_val):
+                    log_message(f"Error: {var}={val} is outside acceptable range [{min_val}, {max_val}]", level="error")
+                    return False
+            except ValueError:
+                log_message(f"Error: {var}='{raw}' is not a valid number", level="error")
+                return False
+
     return True
 
 def get_bitfinex_price(symbol='tBTCUSD', retries=3, delay=5):

--- a/strategy_coinex_fng_ma_buyer.py
+++ b/strategy_coinex_fng_ma_buyer.py
@@ -36,6 +36,25 @@ def validate_env_vars():
     if missing:
         log_message(f"Error: Missing environment variables: {', '.join(missing)}", level="error")
         return False
+
+    amount_vars = {
+        'BUY_OVERLAP_AMOUNT': (0.000001, 10.0),
+        'BUY_FNG_AMOUNT': (0.000001, 10.0),
+        'BUY_MA_AMOUNT': (0.000001, 10.0),
+        'BUY_DAILY_AMOUNT': (0.0, 10.0),
+    }
+    for var, (min_val, max_val) in amount_vars.items():
+        raw = os.environ.get(var)
+        if raw is not None:
+            try:
+                val = float(raw)
+                if val != 0.0 and not (min_val <= val <= max_val):
+                    log_message(f"Error: {var}={val} is outside acceptable range [{min_val}, {max_val}]", level="error")
+                    return False
+            except ValueError:
+                log_message(f"Error: {var}='{raw}' is not a valid number", level="error")
+                return False
+
     return True
 
 def get_coinex_price(symbol='BTCUSDT', retries=3, delay=5):
@@ -137,14 +156,12 @@ def coinex_buy_order(btc_amount, api_key, api_secret, retries=3, delay=5):
 
             # 1. Sort parameters alphabetically (CRITICAL for signature)
             query_string = '&'.join([f"{k}={v}" for k, v in sorted(params.items())])
-            print(f"Query string for signature: {query_string}")
             # 2. Generate signature (HMAC-SHA256, uppercase)
             signature = hmac.new(
                 api_secret.encode('utf-8'),
                 query_string.encode('utf-8'),
                 hashlib.sha256
             ).hexdigest().upper()
-            print(f"Generated signature: {signature}")
             # 3. Set headers (EXACT names and Content-Type)
             headers = {
                 'X-COINEX-ACCESS-ID': api_key,
@@ -152,7 +169,6 @@ def coinex_buy_order(btc_amount, api_key, api_secret, retries=3, delay=5):
                 'X-COINEX-SIGN': signature,
                 'Content-Type': 'application/json'  # Important!
             }
-            print(f"Headers: {headers}")
             # 4. Send POST request with params as JSON body
             response = requests.post(url, headers=headers, data=json.dumps(params), timeout=20)
             response.raise_for_status()  # Raise HTTPError for bad responses (4xx or 5xx)

--- a/strategy_katoshi_fng_ma_buyer.py
+++ b/strategy_katoshi_fng_ma_buyer.py
@@ -35,8 +35,8 @@ def validate_env_vars():
     # REMOVED FNG_THRESHOLD_PERCENT and MA_THRESHOLD_PERCENT from required list
     # because they have default values in the logic.
     required_vars = [
-        'KATOSHI_API_KEY', 
-        'KATOSHI_BOT_ID', 
+        'KATOSHI_API_KEY',
+        'KATOSHI_BOT_ID',
         'KATOSHI_WEBHOOK_ID',
         'TRIGGER_TIME'
     ]
@@ -44,6 +44,25 @@ def validate_env_vars():
     if missing:
         log_message(f"Error: Missing environment variables: {', '.join(missing)}", level="error")
         return False
+
+    amount_vars = {
+        'BUY_OVERLAP_AMOUNT': (0.000001, 10.0),
+        'BUY_FNG_AMOUNT': (0.000001, 10.0),
+        'BUY_MA_AMOUNT': (0.000001, 10.0),
+        'BUY_DAILY_AMOUNT': (0.0, 10.0),
+    }
+    for var, (min_val, max_val) in amount_vars.items():
+        raw = os.environ.get(var)
+        if raw is not None:
+            try:
+                val = float(raw)
+                if val != 0.0 and not (min_val <= val <= max_val):
+                    log_message(f"Error: {var}={val} is outside acceptable range [{min_val}, {max_val}]", level="error")
+                    return False
+            except ValueError:
+                log_message(f"Error: {var}='{raw}' is not a valid number", level="error")
+                return False
+
     return True
 
 def get_hyperliquid_price(coin='BTC', retries=3, delay=5):


### PR DESCRIPTION
- Remove 3 print() statements from coinex_buy_order() that exposed the HMAC signature, query string, and auth headers to stdout/container logs
- Add validate_env_vars() bounds checking for BUY_OVERLAP_AMOUNT, BUY_FNG_AMOUNT, BUY_MA_AMOUNT, BUY_DAILY_AMOUNT across all 3 strategies (must be between 0.000001 and 10.0 BTC when non-zero) to prevent accidental large orders from misconfiguration

https://claude.ai/code/session_01VLExJfpLNBgAY3faepbuTj