### PR TITLE
feat: consistent Sentry init, fix MA threshold default, add DRY_RUN mode

### DIFF
--- a/strategy_bitfinex_fng_ma_buyer.py
+++ b/strategy_bitfinex_fng_ma_buyer.py
@@ -17,11 +17,17 @@ sentry_dsn = os.environ.get('SENTRY_DSN')
 if not sentry_dsn:
     print("Warning: SENTRY_DSN not set. Logging to console only.")
 else:
-    sentry_sdk.init(dsn=sentry_dsn, traces_sample_rate=1.0)
+    try:
+        sentry_sdk.init(dsn=sentry_dsn, traces_sample_rate=1.0)
+        print("Sentry initialized successfully.")
+    except Exception as e:
+        print(f"Warning: Failed to initialize Sentry (Invalid DSN?): {e}. Logging to console only.")
+        sentry_dsn = None
 
 # Configuration
 API_VERSION = 'v2'
 ma_period = int(os.environ.get('MA_PERIOD_DAYS', 730))
+dry_run = os.environ.get('DRY_RUN', 'false').lower() in ('true', '1', 'yes')
 
 # Initialize Bitfinex client
 bfx = BitfinexClient(
@@ -156,6 +162,9 @@ def make_daily_purchase():
         if not api_key or not api_secret:
             log_message("No daily purchase - Missing API credentials", level="error")
             return
+        if dry_run:
+            log_message(f"Daily purchase: DRY RUN - Skipping order for {btc_amount} BTC")
+            return
         order = bitfinex_buy_order(btc_amount)
         current_price = get_bitfinex_price()
         usdt_amount = btc_amount * current_price
@@ -250,6 +259,10 @@ def compute_buy_decision():
     usdt_amount = btc_amount * current_price
     log_message(f"{current_date}: Planning to buy {btc_amount} BTC (~{usdt_amount:.2f} USDT) - {reason}")
 
+    if dry_run:
+        log_message(f"{current_date}: DRY RUN - Skipping order placement for {btc_amount} BTC (~{usdt_amount:.2f} USDT) - {reason}")
+        return f"{current_date}: DRY RUN - Would buy {btc_amount} BTC (~{usdt_amount:.2f} USDT) - {reason}"
+
     try:
         order = bitfinex_buy_order(btc_amount)
         log_message(f"{current_date}: Bought {btc_amount} BTC (~{usdt_amount:.2f} USDT) - {reason} (Order ID: {order['id']})")
@@ -286,7 +299,8 @@ def main():
         f"Buy amount for MA: {os.environ.get('BUY_MA_AMOUNT', 'Not set')}\n"
         f"FNG threshold: {os.environ.get('FNG_THRESHOLD_PERCENT', 'Not set')}\n"
         f"MA threshold: {os.environ.get('MA_THRESHOLD_PERCENT', 'Not set')}\n"
-        f"Daily buy amount: {os.environ.get('BUY_DAILY_AMOUNT', 'Not set')}"
+        f"Daily buy amount: {os.environ.get('BUY_DAILY_AMOUNT', 'Not set')}\n"
+        f"Dry run mode: {'ENABLED' if dry_run else 'Disabled'}"
     )
     log_message(start_message)
 

--- a/strategy_coinex_fng_ma_buyer.py
+++ b/strategy_coinex_fng_ma_buyer.py
@@ -17,11 +17,17 @@ sentry_dsn = os.environ.get('SENTRY_DSN')
 if not sentry_dsn:
     print("Warning: SENTRY_DSN not set. Logging to console only.")
 else:
-    sentry_sdk.init(dsn=sentry_dsn, traces_sample_rate=1.0)
+    try:
+        sentry_sdk.init(dsn=sentry_dsn, traces_sample_rate=1.0)
+        print("Sentry initialized successfully.")
+    except Exception as e:
+        print(f"Warning: Failed to initialize Sentry (Invalid DSN?): {e}. Logging to console only.")
+        sentry_dsn = None
 
 # Configuration
 API_VERSION = 'v2'  # Use API v2
 ma_period = int(os.environ.get('MA_PERIOD_DAYS', 730))  # Default to 730 days
+dry_run = os.environ.get('DRY_RUN', 'false').lower() in ('true', '1', 'yes')
 
 def log_message(message, level="info"):
     """Log message to console and Sentry if configured."""
@@ -270,6 +276,10 @@ def compute_buy_decision():
     usdt_amount = btc_amount * current_price
     log_message(f"{current_date}: Planning to buy {btc_amount} BTC (~{usdt_amount:.2f} USDT) - {reason}")
 
+    if dry_run:
+        log_message(f"{current_date}: DRY RUN - Skipping order placement for {btc_amount} BTC (~{usdt_amount:.2f} USDT) - {reason}")
+        return f"{current_date}: DRY RUN - Would buy {btc_amount} BTC (~{usdt_amount:.2f} USDT) - {reason}"
+
     # Place buy order
     try:
         order = coinex_buy_order(btc_amount, api_key, api_secret)
@@ -306,7 +316,8 @@ def main():
         f"Buy amount for FNG: {os.environ.get('BUY_FNG_AMOUNT', 'Not set')}\n"
         f"Buy amount for MA: {os.environ.get('BUY_MA_AMOUNT', 'Not set')}\n"
         f"FNG threshold: {os.environ.get('FNG_THRESHOLD_PERCENT', 'Not set')}\n"
-        f"MA threshold: {os.environ.get('MA_THRESHOLD_PERCENT', 'Not set')}"
+        f"MA threshold: {os.environ.get('MA_THRESHOLD_PERCENT', 'Not set')}\n"
+        f"Dry run mode: {'ENABLED' if dry_run else 'Disabled'}"
     )
     log_message(start_message)
 

--- a/strategy_katoshi_fng_ma_buyer.py
+++ b/strategy_katoshi_fng_ma_buyer.py
@@ -23,6 +23,7 @@ else:
 
 # Configuration
 ma_period = int(os.environ.get('MA_PERIOD_DAYS', 730))
+dry_run = os.environ.get('DRY_RUN', 'false').lower() in ('true', '1', 'yes')
 
 def log_message(message, level="info"):
     """Log message to console and Sentry if configured."""
@@ -197,6 +198,9 @@ def make_daily_purchase():
              log_message("No daily purchase - Missing environment variables", level="error")
              return
 
+        if dry_run:
+            log_message(f"Daily purchase: DRY RUN - Skipping order for {btc_amount} BTC")
+            return
         order = katoshi_buy_order(btc_amount)
         current_price = get_hyperliquid_price()
         usdt_amount = btc_amount * current_price
@@ -247,7 +251,7 @@ def compute_buy_decision():
 
     try:
         fng_threshold = float(os.environ.get('FNG_THRESHOLD_PERCENT', 25))
-        ma_threshold = float(os.environ.get('MA_THRESHOLD_PERCENT', 0.0))
+        ma_threshold = float(os.environ.get('MA_THRESHOLD_PERCENT', 0.1))
         
         # Auto-correct if user provides whole number percentage (e.g. 5 instead of 0.05)
         if ma_threshold >= 1:
@@ -292,6 +296,10 @@ def compute_buy_decision():
     usdt_amount = btc_amount * current_price
     log_message(f"{current_date}: Planning to buy {btc_amount} BTC (~{usdt_amount:.2f} USD) - {reason}")
 
+    if dry_run:
+        log_message(f"{current_date}: DRY RUN - Skipping order placement for {btc_amount} BTC (~{usdt_amount:.2f} USD) - {reason}")
+        return f"{current_date}: DRY RUN - Would buy {btc_amount} BTC (~{usdt_amount:.2f} USD) - {reason}"
+
     try:
         order = katoshi_buy_order(btc_amount)
         log_message(f"{current_date}: Bought {btc_amount} BTC (~{usdt_amount:.2f} USD) - {reason} (Katoshi Resp: {order['id']})")
@@ -329,7 +337,8 @@ def main():
         f"Buy amount for MA: {os.environ.get('BUY_MA_AMOUNT', 'Not set')}\n"
         f"FNG threshold: {os.environ.get('FNG_THRESHOLD_PERCENT', 'Not set')}\n"
         f"MA threshold: {os.environ.get('MA_THRESHOLD_PERCENT', 'Not set')}\n"
-        f"Daily buy amount: {os.environ.get('BUY_DAILY_AMOUNT', 'Not set')}"
+        f"Daily buy amount: {os.environ.get('BUY_DAILY_AMOUNT', 'Not set')}\n"
+        f"Dry run mode: {'ENABLED' if dry_run else 'Disabled'}"
     )
     log_message(start_message)
 


### PR DESCRIPTION
- Wrap sentry_sdk.init() in try/except in Bitfinex and CoinEx strategies to match Katoshi's pattern — prevents crash on invalid DSN
- Fix MA_THRESHOLD_PERCENT default in Katoshi from 0.0 to 0.1 to match Bitfinex/CoinEx and avoid MA trigger being silently disabled
- Add DRY_RUN=true env var support to all 3 strategies: when enabled, the strategy runs the full decision logic but skips actual order placement, logging what would have been bought instead

https://claude.ai/code/session_01VLExJfpLNBgAY3faepbuTj